### PR TITLE
Change UserInfo client component to a server component

### DIFF
--- a/components/layout/user-info.tsx
+++ b/components/layout/user-info.tsx
@@ -1,9 +1,8 @@
-'use client';
+import { UserButton } from '@clerk/nextjs';
+import { currentUser } from '@clerk/nextjs/server';
 
-import { UserButton, useUser } from '@clerk/nextjs';
-
-function UserInfo() {
-	const { user } = useUser();
+async function UserInfo() {
+	const user = await currentUser();
 	return (
 		<div className="flex items-center gap-x-3">
 			<UserButton


### PR DESCRIPTION
Removed `useUser()` hook and used server-side `currentUser()` helper instead to get the currently logged in user.

For more information: https://clerk.com/docs/references/nextjs/read-session-data