### PR TITLE
Add tests for account creation and deletion

### DIFF
--- a/app/(dashboard)/accounts/columns.tsx
+++ b/app/(dashboard)/accounts/columns.tsx
@@ -1,13 +1,12 @@
 'use client';
 
-import { InferResponseType } from 'hono';
 import { ColumnDef } from '@tanstack/react-table';
 
-import { client } from '@/lib/hono';
 import { Checkbox } from '@/components/ui/checkbox';
 import SortableColumnHeader from '@/components/ui/sortable-column-header';
+import { AccountsGetResponseType } from '@/types/accounts';
 
-export type Account = InferResponseType<typeof client.api.accounts.$get>['data'][0];
+export type Account = AccountsGetResponseType['data'][0];
 
 export const columns: ColumnDef<Account>[] = [
 	{

--- a/app/(dashboard)/accounts/page.tsx
+++ b/app/(dashboard)/accounts/page.tsx
@@ -36,6 +36,7 @@ function AccountsPage() {
 						bulkDeleteMutate({ ids });
 					}}
 					disabled={isDeleting}
+					tableCaption="A list of your accounts"
 				/>
 			) : (
 				<p className="text-center min-h-[65vh] flex items-center justify-center">

--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -18,6 +18,7 @@ import {
 import {
 	Table,
 	TableBody,
+	TableCaption,
 	TableCell,
 	TableHead,
 	TableHeader,
@@ -35,6 +36,7 @@ interface DataTableProps<TData, TValue> {
 	filterKey: string;
 	onDelete: (rows: Row<TData>[]) => void;
 	disabled?: boolean;
+	tableCaption: string;
 }
 
 export function DataTable<TData, TValue>({
@@ -43,6 +45,7 @@ export function DataTable<TData, TValue>({
 	filterKey,
 	onDelete,
 	disabled,
+	tableCaption,
 }: DataTableProps<TData, TValue>) {
 	const [sorting, setSorting] = useState<SortingState>([]);
 	const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -105,6 +108,7 @@ export function DataTable<TData, TValue>({
 			</div>
 			<div className="rounded-md border">
 				<Table>
+					<TableCaption className="sr-only">{tableCaption}</TableCaption>
 					<TableHeader>
 						{table.getHeaderGroups().map(headerGroup => (
 							<TableRow key={headerGroup.id}>

--- a/features/accounts/hooks/api/use-bulk-delete.ts
+++ b/features/accounts/hooks/api/use-bulk-delete.ts
@@ -1,20 +1,20 @@
-import { client } from '@/lib/hono';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { InferRequestType, InferResponseType } from 'hono';
 import { toast } from 'sonner';
 
-type ResponseType = InferResponseType<
-	(typeof client.api.accounts)['bulk-delete']['$post']
->;
-
-type RequestType = InferRequestType<
-	(typeof client.api.accounts)['bulk-delete']['$post']
->['json'];
+import { client } from '@/lib/hono';
+import {
+	AccountBulkDeleteRequestType,
+	AccountBulkDeleteResponseType,
+} from '@/types/accounts';
 
 export function useBulkDelete() {
 	const queryClient = useQueryClient();
 
-	return useMutation<ResponseType, Error, RequestType>({
+	return useMutation<
+		AccountBulkDeleteResponseType,
+		Error,
+		AccountBulkDeleteRequestType['json']
+	>({
 		mutationFn: async data => {
 			const response = await client.api.accounts['bulk-delete']['$post']({ json: data });
 			return await response.json();
@@ -23,8 +23,8 @@ export function useBulkDelete() {
 			toast.success(`Account${data.length > 1 ? 's' : ''} deleted successfully!`);
 			queryClient.invalidateQueries({ queryKey: ['accounts'] });
 		},
-		onError: error => {
-			toast.error(error.message);
+		onError: (_error, variables) => {
+			toast.error(`Failed to delete account${variables.ids.length > 1 ? 's' : ''}.`);
 		},
 	});
 }

--- a/features/accounts/hooks/api/use-create-account.ts
+++ b/features/accounts/hooks/api/use-create-account.ts
@@ -1,16 +1,13 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { InferRequestType, InferResponseType } from 'hono';
 import { toast } from 'sonner';
 
 import { client } from '@/lib/hono';
-
-type ResponseType = InferResponseType<typeof client.api.accounts.$post>;
-type RequestType = InferRequestType<typeof client.api.accounts.$post>['json'];
+import { AccountCreateRequestType, AccountCreateResponseType } from '@/types/accounts';
 
 export function useCreateAccount() {
 	const queryClient = useQueryClient();
 
-	return useMutation<ResponseType, Error, RequestType>({
+	return useMutation<AccountCreateResponseType, Error, AccountCreateRequestType['json']>({
 		mutationFn: async data => {
 			const response = await client.api.accounts.$post({ json: data });
 			return await response.json();
@@ -19,8 +16,8 @@ export function useCreateAccount() {
 			toast.success('Account created successfully!');
 			queryClient.invalidateQueries({ queryKey: ['accounts'] });
 		},
-		onError: error => {
-			toast.error(error.message);
+		onError: () => {
+			toast.error('Failed to create an account.');
 		},
 	});
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {
-		"dev": "next dev --turbo",
+		"dev": "next dev",
 		"build": "next build",
 		"start": "next start",
 		"lint": "next lint",

--- a/test/fixtures/accounts.ts
+++ b/test/fixtures/accounts.ts
@@ -1,8 +1,6 @@
-import { InferResponseType } from 'hono';
+import { AccountsGetResponseType } from '@/types/accounts';
 
-import { client } from '@/lib/hono';
-
-export const accounts: InferResponseType<typeof client.api.accounts.$get>['data'] = [
+export const accounts: AccountsGetResponseType['data'] = [
 	{ id: 1, name: 'Test 1' },
 	{ id: 2, name: 'Test 2' },
 ];

--- a/test/mocks/domains/accounts.ts
+++ b/test/mocks/domains/accounts.ts
@@ -1,15 +1,43 @@
 import { DefaultBodyType, http, HttpResponse, PathParams } from 'msw';
-import { InferResponseType } from 'hono';
 
-import { client } from '@/lib/hono';
 import { accounts } from '@/test/fixtures/accounts';
+import { ACCOUNTS_BASE_URL } from '@/utils/constants';
+import {
+	AccountBulkDeleteRequestType,
+	AccountBulkDeleteResponseType,
+	AccountCreateRequestType,
+	AccountCreateResponseType,
+	AccountsGetResponseType,
+} from '@/types/accounts';
 
 export const accountHandlers = [
-	http.get<
+	http.get<PathParams, DefaultBodyType, AccountsGetResponseType>(
+		ACCOUNTS_BASE_URL,
+		() => {
+			return HttpResponse.json({ data: accounts });
+		},
+	),
+	http.post<PathParams, AccountCreateRequestType['json'], AccountCreateResponseType>(
+		ACCOUNTS_BASE_URL,
+		async ({ request }) => {
+			const body = await request.json();
+			const newPost = {
+				id: accounts.length + 1,
+				name: body.name,
+				userId: 'test',
+				plaidId: null,
+				createdAt: new Date().toISOString(),
+			};
+
+			return HttpResponse.json({ data: newPost }, { status: 201 });
+		},
+	),
+	http.post<
 		PathParams,
-		DefaultBodyType,
-		InferResponseType<typeof client.api.accounts.$get>
-	>(`${process.env.NEXT_PUBLIC_APP_URL}/api/accounts`, () => {
-		return HttpResponse.json({ data: accounts });
+		AccountBulkDeleteRequestType['json'],
+		AccountBulkDeleteResponseType
+	>(`${ACCOUNTS_BASE_URL}/bulk-delete`, async ({ request }) => {
+		const body = await request.json();
+		return HttpResponse.json({ data: body.ids.map(id => ({ id })) });
 	}),
 ];

--- a/types/accounts.ts
+++ b/types/accounts.ts
@@ -1,0 +1,19 @@
+import { InferRequestType, InferResponseType } from 'hono';
+
+import { client } from '@/lib/hono';
+
+export type AccountsGetResponseType = InferResponseType<typeof client.api.accounts.$get>;
+
+export type AccountCreateRequestType = InferRequestType<typeof client.api.accounts.$post>;
+
+export type AccountCreateResponseType = InferResponseType<
+	typeof client.api.accounts.$post
+>;
+
+export type AccountBulkDeleteRequestType = InferRequestType<
+	(typeof client.api.accounts)['bulk-delete']['$post']
+>;
+
+export type AccountBulkDeleteResponseType = InferResponseType<
+	(typeof client.api.accounts)['bulk-delete']['$post']
+>;

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,0 +1,1 @@
+export const ACCOUNTS_BASE_URL = `${process.env.NEXT_PUBLIC_APP_URL}/api/accounts`;


### PR DESCRIPTION
This PR includes the following changes:
- add tests for account creation and deletion
- remove `turbo` flag from `dev` script
- add a caption for accounts table
- specify error messages for account creation and deletion
- create accounts base API URL constant and request/response types as part of refactoring accounts code