### PR TITLE
Refactor accounts table, useEditAccount hook, and useSelectedId hook

### DIFF
--- a/app/(dashboard)/accounts/page.tsx
+++ b/app/(dashboard)/accounts/page.tsx
@@ -1,64 +1,25 @@
 'use client';
 
 import RestrictiveContainer from '@/components/container/restrictive-container';
-import { DataTable } from '@/components/ui/data-table';
+import AccountsTable from '@/features/accounts/components/accounts-table';
 import CreateAccountSheet from '@/features/accounts/components/create-account-sheet';
-import { columns } from './columns';
-import { useAccounts } from '@/features/accounts/hooks/api/use-accounts';
-import LoadingSpinner from '@/components/ui/loading-spinner';
-import { useBulkDelete } from '@/features/accounts/hooks/api/use-bulk-delete';
 import EditAccountSheet from '@/features/accounts/components/edit-account-sheet';
 import { useSelectedId } from '@/hooks/use-selected-id';
-import { useDeleteAccount } from '@/features/accounts/hooks/api/use-delete-account';
 
 function AccountsPage() {
-	const { data: accounts, isLoading: isAccountsLoading, isError, error } = useAccounts();
-	const { isPending: isBulkDeleting, mutate: bulkDeleteMutate } = useBulkDelete();
-	const { mutate: deleteMutate } = useDeleteAccount();
-
-	const { selectedId, isOpen, handleClose, handleOpen } = useSelectedId();
-
+	const { selectedId, isSelectedId, unsetId, setId } = useSelectedId();
 	return (
 		<RestrictiveContainer>
 			<EditAccountSheet
 				accountId={selectedId}
-				isOpen={isOpen}
-				handleClose={handleClose}
+				isOpen={isSelectedId}
+				handleClose={unsetId}
 			/>
 			<div className="flex flex-col gap-2 xs:flex-row xs:items-center xs:justify-between">
 				<h1 className=" font-bold text-2xl sm:text-3xl">Accounts</h1>
 				<CreateAccountSheet />
 			</div>
-			{isAccountsLoading ? (
-				<div className="flex items-center justify-center min-h-[300px]">
-					<LoadingSpinner />
-				</div>
-			) : isError ? (
-				<p className="text-center min-h-[65vh] flex items-center justify-center text-red-600 font-semibold">
-					{error.message}
-				</p>
-			) : accounts && accounts.length > 0 ? (
-				<DataTable
-					columns={columns}
-					data={accounts}
-					filterKey="name"
-					onBulkDelete={rows => {
-						const ids = rows.map(row => row.original.id);
-						bulkDeleteMutate({ ids });
-					}}
-					onDelete={(id: number) => {
-						deleteMutate({ id: id.toString() });
-					}}
-					disabled={isBulkDeleting}
-					tableCaption="A list of your accounts"
-					onClickEdit={handleOpen}
-				/>
-			) : (
-				<p className="text-center min-h-[65vh] flex items-center justify-center">
-					You do not have any accounts. Create an account to start tracking your
-					transactions.
-				</p>
-			)}
+			<AccountsTable onClickEdit={setId} />
 		</RestrictiveContainer>
 	);
 }

--- a/features/accounts/components/accounts-table.tsx
+++ b/features/accounts/components/accounts-table.tsx
@@ -1,0 +1,53 @@
+import { DataTable } from '@/components/ui/data-table';
+import { columns } from '@/app/(dashboard)/accounts/columns';
+import { useAccounts } from '@/features/accounts/hooks/api/use-accounts';
+import LoadingSpinner from '@/components/ui/loading-spinner';
+import { useBulkDelete } from '@/features/accounts/hooks/api/use-bulk-delete';
+import { useDeleteAccount } from '@/features/accounts/hooks/api/use-delete-account';
+
+interface AccountsTableProps {
+	onClickEdit?: (id: number) => void;
+}
+
+function AccountsTable({ onClickEdit }: AccountsTableProps) {
+	const { data: accounts, isLoading: isAccountsLoading, isError, error } = useAccounts();
+	const { isPending: isBulkDeleting, mutate: bulkDeleteMutate } = useBulkDelete();
+	const { mutate: deleteMutate } = useDeleteAccount();
+
+	return (
+		<>
+			{isAccountsLoading ? (
+				<div className="flex items-center justify-center min-h-[300px]">
+					<LoadingSpinner />
+				</div>
+			) : isError ? (
+				<p className="text-center min-h-[65vh] flex items-center justify-center text-red-600 font-semibold">
+					{error.message}
+				</p>
+			) : accounts && accounts.length > 0 ? (
+				<DataTable
+					columns={columns}
+					data={accounts}
+					tableCaption="A list of your accounts"
+					filterKey="name"
+					disabled={isBulkDeleting}
+					onBulkDelete={rows => {
+						const ids = rows.map(row => row.original.id);
+						bulkDeleteMutate({ ids });
+					}}
+					onDelete={(id: number) => {
+						deleteMutate({ id: id.toString() });
+					}}
+					onClickEdit={onClickEdit}
+				/>
+			) : (
+				<p className="text-center min-h-[65vh] flex items-center justify-center">
+					You do not have any accounts. Create an account to start tracking your
+					transactions.
+				</p>
+			)}
+		</>
+	);
+}
+
+export default AccountsTable;

--- a/features/accounts/components/edit-account-form.tsx
+++ b/features/accounts/components/edit-account-form.tsx
@@ -35,14 +35,17 @@ function EditAccountForm({ accountId, onSuccess, defaultValues }: EditAccountFor
 
 	const formErrors = form.formState.errors;
 
-	const mutation = useEditAccount(accountId);
+	const mutation = useEditAccount();
 
 	function onSubmit(formData: FormData) {
-		mutation.mutate(formData, {
-			onSuccess: () => {
-				onSuccess?.();
+		mutation.mutate(
+			{ param: { id: accountId?.toString() }, json: formData },
+			{
+				onSuccess: () => {
+					onSuccess?.();
+				},
 			},
-		});
+		);
 	}
 
 	return (

--- a/features/accounts/hooks/api/use-edit-account.ts
+++ b/features/accounts/hooks/api/use-edit-account.ts
@@ -3,14 +3,14 @@ import { AccountEditRequestType, AccountEditResponseType } from '@/types/account
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
-export function useEditAccount(id: number | undefined) {
+export function useEditAccount() {
 	const queryClient = useQueryClient();
 
-	return useMutation<AccountEditResponseType, Error, AccountEditRequestType['json']>({
-		mutationFn: async data => {
+	return useMutation<AccountEditResponseType, Error, AccountEditRequestType>({
+		mutationFn: async ({ param, json }) => {
 			const response = await client.api.accounts[':id']['$patch']({
-				param: { id: id?.toString() },
-				json: data,
+				param,
+				json,
 			});
 
 			if (!response.ok) {

--- a/hooks/use-selected-id.tsx
+++ b/hooks/use-selected-id.tsx
@@ -1,21 +1,21 @@
 import { useState } from 'react';
 
 /**
- * This hook keeps track of the currently selected ID. It can be used to control the open and close state of a component that shows some data related to the ID, for example, a modal component that contains a form to edit something.
+ * This hook keeps track of the currently selected ID. It can be used to control the state of a component that shows some data based on the selected ID, for example, the open and close state of a modal component that contains a form to edit a post.
  */
 
 export function useSelectedId() {
 	const [selectedId, setSelectedId] = useState<undefined | number>(undefined);
 
-	const isOpen = selectedId !== undefined;
+	const isSelectedId = selectedId !== undefined;
 
-	function handleOpen(id: number) {
+	function setId(id: number) {
 		setSelectedId(id);
 	}
 
-	function handleClose() {
+	function unsetId() {
 		setSelectedId(undefined);
 	}
 
-	return { isOpen, selectedId, handleOpen, handleClose };
+	return { isSelectedId, selectedId, setId, unsetId };
 }


### PR DESCRIPTION
This PR contains the following changes:
- created an accounts table component and moved data table corresponding to accounts and accounts data fetching and mutation logic into it
- included `params` object containing account ID in the parameter for `useEditAccount` hook's mutation function
- renamed functions and variables of `useSelectedId` hook